### PR TITLE
use `useRef` instead of `useMemo`

### DIFF
--- a/lib/apolloClient.js
+++ b/lib/apolloClient.js
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useRef } from "react";
 import { ApolloClient, HttpLink, InMemoryCache, from } from "@apollo/client";
 import { onError } from "@apollo/client/link/error";
 import merge from "deepmerge";
@@ -68,6 +68,9 @@ export function addApolloState(client, pageProps) {
 
 export function useApollo(pageProps) {
   const state = pageProps[APOLLO_STATE_PROP_NAME];
-  const store = useMemo(() => initializeApollo(state), [state]);
-  return store;
+  const storeRef = useRef();
+  if (!storeRef.current) {
+    storeRef.current = initializeApollo(state);
+  }
+  return storeRef.current;
 }


### PR DESCRIPTION
We should probably not encourage keeping the Apollo Cache in `useMemo`, as React sees that only as a performance optimization and can throw that away.

See [the React Documentation](https://react.dev/reference/react/useMemo):

> React will not throw away the cached value unless there is a specific reason to do that. For example, in development, React throws away the cache when you edit the file of your component. Both in development and in production, React will throw away the cache if your component suspends during the initial mount. In the future, React may add more features that take advantage of throwing away the cache—for example, if React adds built-in support for virtualized lists in the future, it would make sense to throw away the cache for items that scroll out of the virtualized table viewport. **This should be fine if you rely on useMemo solely as a performance optimization. Otherwise, a [state variable](https://react.dev/reference/react/useState#avoiding-recreating-the-initial-state) or a [ref](https://react.dev/reference/react/useRef#avoiding-recreating-the-ref-contents) may be more appropriate.**